### PR TITLE
removed curl_escape from request function

### DIFF
--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -44,7 +44,7 @@ final class CurlClient
         }
 
         $headers = [];
-        $completeUrl = $this->baseUrl . curl_escape($ch, $url);
+        $completeUrl = $this->baseUrl . $url;
 
         if (!$this->sslVerify) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
curl_escape used here will escape the entire pathname, which results in a 404 from the Data API. It urlencodes the slashes, which in our testing chokes the Data API. 

Without this change, the login function fails every time.

Credit goes to @steveAllen0112 for helping figure out exactly where this was going wrong. 

