### PR TITLE
wrap database name in rawurlencode

### DIFF
--- a/src/DataApi.php
+++ b/src/DataApi.php
@@ -34,7 +34,7 @@ final class DataApi implements DataApiInterface
      */
     public function __construct($apiUrl, $apiDatabase, $apiUser = null, $apiPassword = null, $sslVerify = true)
     {
-        $this->apiDatabase   = $apiDatabase;
+        $this->apiDatabase   = rawurlencode(trim($apiDatabase));
         $this->ClientRequest = new CurlClient($apiUrl, $sslVerify);
 
         if (!empty($apiUser)) {


### PR DESCRIPTION
curl_escape was removed in a previous PR, and as such the database name specifically still needs to be urlencoded in case it has spaces etc, so do that here.