### PR TITLE
rewrite prepareScriptOptions to be clearer

### DIFF
--- a/src/DataApi.php
+++ b/src/DataApi.php
@@ -495,9 +495,7 @@ final class DataApi implements DataApiInterface
                 case self::SCRIPT_POSTREQUEST:
                     $preparedScript['script'] = $script['name'];
                     if (array_key_exists('param', $script)) {
-                        if ($script['param'] === '') {
-                            unset($script['param']);
-                        } elseif ($script['param'] === null) {
+                        if (empty($script['param'])) {
                             unset($script['param']);
                         } else {
                             $preparedScript['script.param'] = $script['param'];

--- a/src/DataApi.php
+++ b/src/DataApi.php
@@ -494,12 +494,14 @@ final class DataApi implements DataApiInterface
                     break;
                 case self::SCRIPT_POSTREQUEST:
                     $preparedScript['script'] = $script['name'];
-                    if ($script['param'] === '') {
-                        unset($script['param']);
-                    } elseif ($script['param'] === null) {
-                        unset($script['param']);
-                    } else {
-                        $preparedScript['script.param'] = $script['param'];
+                    if (array_key_exists('param', $script)) {
+                        if ($script['param'] === '') {
+                            unset($script['param']);
+                        } elseif ($script['param'] === null) {
+                            unset($script['param']);
+                        } else {
+                            $preparedScript['script.param'] = $script['param'];
+                        }
                     }
                     break;
                 default:


### PR DESCRIPTION
Making the code much more verbose and comprehensible by converting it to a switch statement. This also solves the previous code's issue where if you omitted the script parameter for a POSTREQUEST script's parameter, it would send a null or blank one to the Data API anyway, which the Data API chokes on. New code otherwise maintains exact function of previous code, possible bugs included.